### PR TITLE
Advance ical end timestamp by one day, tweak formatting.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,4 @@ domain: confa11y.com
 
 future: true
 markdown: kramdown
+timezone: UTC

--- a/conferences.ics
+++ b/conferences.ics
@@ -9,6 +9,8 @@ NAME:{{ site.domain }}
 X-WR-CALNAME:{{ site.domain }}
 DESCRIPTION:{{ site.description | replace: ",","\\," }}
 X-WR-CALDESC:{{ site.description | replace: ",","\\," }}
+REFRESH-INTERVAL;VALUE=DURATION:PT5M
+X-PUBLISHED-TTL:PT5M
 METHOD:PUBLISH
 {% for post in site.posts %}BEGIN:VEVENT
 UID:{{ post.date | date: "%Y%m%d" }}@{{ site.domain }}

--- a/conferences.ics
+++ b/conferences.ics
@@ -22,7 +22,7 @@ URL;TYPE=URI:{{ post.site }}
 CLASS:PUBLIC
 DTSTAMP:{{ post.from | date: "%Y%m%d" }}T170000Z
 DTSTART;VALUE=DATE:{{ post.from | date: "%Y%m%d" }}
-DTEND;VALUE=DATE:{{ post.to | date: "%Y%m%d" }}
+DTEND;VALUE=DATE:{{ post.to | date: "%s" | plus: 86400 | date: "%Y%m%d" }}
 END:VEVENT
 {% endfor %}
 END:VCALENDAR

--- a/conferences.ics
+++ b/conferences.ics
@@ -7,15 +7,15 @@ PRODID:{{ site.domain }}
 CALSCALE:GREGORIAN
 NAME:{{ site.domain }}
 X-WR-CALNAME:{{ site.domain }}
-DESCRIPTION:{{ site.description }}
-X-WR-CALDESC:{{ site.description }}
+DESCRIPTION:{{ site.description | replace: ",","\\," }}
+X-WR-CALDESC:{{ site.description | replace: ",","\\," }}
 METHOD:PUBLISH
 {% for post in site.posts %}BEGIN:VEVENT
 UID:{{ post.date | date: "%Y%m%d" }}@{{ site.domain }}
 ORGANIZER;CN="{{ site.title }}":MAILTO:ical@{{ site.domain }}
-LOCATION:{{ post.city }}
-SUMMARY:{{ post.title }}
-DESCRIPTION:{{ post.services | join: ", " }}
+LOCATION:{{ post.city | replace: ",","\\," }}
+SUMMARY:{{ post.title | replace: ",","\\," }}
+DESCRIPTION:{{ post.services | join: "\\, " }}
 URL;TYPE=URI:{{ post.site }}
 CLASS:PUBLIC
 DTSTAMP:{{ post.from | date: "%Y%m%d" }}T170000Z


### PR DESCRIPTION
Related to #8.
- iCal’s end date for all-day events is exclusive rather than inclusive.
- We can specify a default refresh interval for clients.
- Commas need to be escaped.
